### PR TITLE
Show unavailable/deprecated symbols

### DIFF
--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -178,6 +178,11 @@ module Jazzy
         "with #{undocumented.count} undocumented symbol" \
         "#{undocumented.count == 1 ? '' : 's'}"
 
+      puts "Undocumented symbols:"
+      undocumented.each do |declaration|
+        puts declaration.fully_qualified_name
+      end
+
       unless options.skip_documentation
         build_site(docs, coverage, options)
       end

--- a/lib/jazzy/doc_builder.rb
+++ b/lib/jazzy/doc_builder.rb
@@ -343,6 +343,9 @@ module Jazzy
         url:                        (item.url if item.children.any?),
         start_line:                 item.start_line,
         end_line:                   item.end_line,
+        deprecation_message:        (item.deprecation_message if item.deprecated),
+        unavailable_message:        (item.unavailable_message if item.unavailable),
+        usage_discouraged:          item.deprecated || item.unavailable,
       }
       item_render.reject { |_, v| v.nil? }
     end

--- a/lib/jazzy/source_declaration.rb
+++ b/lib/jazzy/source_declaration.rb
@@ -76,6 +76,10 @@ module Jazzy
     attr_accessor :start_line
     attr_accessor :end_line
     attr_accessor :nav_order
+    attr_accessor :deprecated
+    attr_accessor :deprecation_message
+    attr_accessor :unavailable
+    attr_accessor :unavailable_message
 
     def overview
       "#{alternative_abstract}\n\n#{abstract}\n\n#{discussion}".strip

--- a/lib/jazzy/sourcekitten.rb
+++ b/lib/jazzy/sourcekitten.rb
@@ -201,6 +201,8 @@ module Jazzy
       declaration.abstract = 'Undocumented'
       declaration.parameters = []
       declaration.children = []
+      declaration.unavailable_message = ''
+      declaration.deprecation_message = ''
     end
 
     def self.documented_child?(doc)
@@ -308,6 +310,8 @@ module Jazzy
       declaration.abstract = Jazzy.markdown.render(doc['key.doc.comment'] || '')
       declaration.discussion = ''
       declaration.return = make_paragraphs(doc, 'key.doc.result_discussion')
+      declaration.deprecation_message = Jazzy.markdown.render(doc['key.deprecation_message'] || '')
+      declaration.unavailable_message = Jazzy.markdown.render(doc['key.unavailable_message'] || '')
 
       declaration.parameters = parameters(doc)
 
@@ -371,6 +375,8 @@ module Jazzy
         declaration.column = doc['key.doc.column']
         declaration.start_line = doc['key.parsed_scope.start']
         declaration.end_line = doc['key.parsed_scope.end']
+        declaration.deprecated = doc['key.always_deprecated']
+        declaration.unavailable = doc['key.always_unavailable']
 
         next unless make_doc_info(doc, declaration)
         make_substructure(doc, declaration)
@@ -572,6 +578,8 @@ module Jazzy
 
         doc.return = autolink_text(doc.return, doc, root_decls) if doc.return
         doc.abstract = autolink_text(doc.abstract, doc, root_decls)
+        doc.unavailable_message = autolink_text(doc.unavailable_message, doc, root_decls) if doc.unavailable_message
+        doc.deprecation_message = autolink_text(doc.deprecation_message, doc, root_decls) if doc.deprecation_message
 
         if doc.declaration
           doc.declaration = autolink_text(

--- a/lib/jazzy/themes/apple/templates/task.mustache
+++ b/lib/jazzy/themes/apple/templates/task.mustache
@@ -15,7 +15,12 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -32,6 +37,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}

--- a/lib/jazzy/themes/fullwidth/templates/task.mustache
+++ b/lib/jazzy/themes/fullwidth/templates/task.mustache
@@ -15,7 +15,12 @@
         <code>
         <a name="/{{usr}}"></a>
         <a name="//apple_ref/{{language_stub}}/{{dash_type}}/{{name}}" class="dashAnchor"></a>
+        {{^usage_discouraged}}
         <a class="token" href="#/{{usr}}">{{name}}</a>
+        {{/usage_discouraged}}
+        {{#usage_discouraged}}
+        <a class="token" href="#/{{usr}}"><strike>{{name}}</strike></a>
+        {{/usage_discouraged}}
         </code>
         {{#default_impl_abstract}}
           <span class="declaration-note">
@@ -32,6 +37,18 @@
         <div class="pointer-container"></div>
         <section class="section">
           <div class="pointer"></div>
+          {{#deprecation_message}}
+          <div class="aside">
+            <p class="aside-title">Deprecated</p>
+            {{{deprecation_message}}}
+          </div>
+          {{/deprecation_message}}
+          {{#unavailable_message}}
+          <div class="aside">
+            <p class="aside-title">Unavailable</p>
+            {{{unavailable_message}}}
+          </div>
+          {{/unavailable_message}}
           {{#abstract}}
           <div class="abstract">
             {{{abstract}}}


### PR DESCRIPTION
Adds support for marking unavailable and deprecated symbols alongside the deprecation or unavailable message.

This adds a strikethrough of unavailable and deprecated APIs and shows a notice, with more details, when the symbol has been expanded, for the default themes.

<img width="683" alt="screen shot 2018-06-15 at 15 07 38" src="https://user-images.githubusercontent.com/5294262/41469667-675d1e82-70ae-11e8-924b-9c5103af62df.png">
<img width="839" alt="screen shot 2018-06-15 at 15 16 19" src="https://user-images.githubusercontent.com/5294262/41469852-1a8a0a88-70af-11e8-92df-b18c48f2dd5f.png">

(Builds on top of https://github.com/PSPDFKit-labs/jazzy/tree/print-undocumented which also hasn't been merged to `master` yet.)